### PR TITLE
Add example feature with shared ViewModel

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -30,15 +30,16 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
 
 dependencies {
+    implementation(libs.androidx.compose.bom)
     implementation(projects.shared)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)

--- a/androidApp/src/main/java/pl/radoslav/bikeer/android/MainActivity.kt
+++ b/androidApp/src/main/java/pl/radoslav/bikeer/android/MainActivity.kt
@@ -3,24 +3,20 @@ package pl.radoslav.bikeer.android
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.activity.viewModels
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import pl.radoslav.bikeer.Greeting
+import pl.radoslav.bikeer.android.examplefeature.presentation.ExampleFeatureScreen
+import pl.radoslav.bikeer.examplefeature.presentation.CounterViewModel
 
 class MainActivity : ComponentActivity() {
+    private val counterViewModel: CounterViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             MyApplicationTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    GreetingView(Greeting().greet())
-                }
+                ExampleFeatureScreen(viewModel = counterViewModel)
             }
         }
     }

--- a/androidApp/src/main/java/pl/radoslav/bikeer/android/examplefeature/presentation/ExampleFeatureScreen.kt
+++ b/androidApp/src/main/java/pl/radoslav/bikeer/android/examplefeature/presentation/ExampleFeatureScreen.kt
@@ -1,0 +1,57 @@
+package pl.radoslav.bikeer.android.examplefeature.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.tooling.preview.Preview
+import pl.radoslav.bikeer.examplefeature.presentation.CounterEvent
+import pl.radoslav.bikeer.examplefeature.presentation.CounterViewModel
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ExampleFeatureScreen(
+    viewModel: CounterViewModel
+) {
+    val state by viewModel.state.collectAsState()
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(
+            "Counter: ${state.counter}",
+            style = TextStyle(
+                fontSize = 24.sp,
+                color = Color.White
+            )
+        )
+        Spacer(modifier = Modifier.height(64.dp))
+        Row {
+            Button(onClick = { viewModel.onEvent(CounterEvent.Decrement) }) {
+                Text(text = "Decrement")
+            }
+            Button(onClick = { viewModel.onEvent(CounterEvent.Increment) }) {
+                Text(text = "Increment")
+            }
+        }
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun ExampleFeatureScreenPreview() {
+    ExampleFeatureScreen(viewModel = CounterViewModel())
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,6 @@ plugins {
     alias(libs.plugins.androidLibrary).apply(false)
     alias(libs.plugins.kotlinAndroid).apply(false)
     alias(libs.plugins.kotlinMultiplatform).apply(false)
+    id("com.google.devtools.ksp") version "1.9.22-1.0.17"
+    id("com.rickclephas.kmp.nativecoroutines") version "1.0.0-ALPHA-25"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,21 @@
 [versions]
-agp = "8.2.0"
-kotlin = "1.9.20"
-compose = "1.5.4"
-compose-compiler = "1.5.4"
-compose-material3 = "1.1.2"
-androidx-activityCompose = "1.8.0"
+agp = "8.3.0"
+composeBom = "2024.02.01"
+dateTimeVersion = "0.4.1"
+kmmViewmodelCoreVersion = "1.0.0-ALPHA-19"
+kotlin = "1.9.22"
+compose = "1.6.2"
+compose-compiler = "1.5.10"
+compose-material3 = "1.2.0"
+androidx-activityCompose = "1.8.2"
+coroutinesCore = "1.7.3"
+ktorVersion = "2.3.7"
+sqlDelightVersion = "1.5.5"
+
 
 [libraries]
+android-driver = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqlDelightVersion" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
@@ -14,6 +23,16 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = 
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "compose-material3" }
+coroutines-core = {group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutinesCore"}
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "dateTimeVersion" }
+ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktorVersion" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktorVersion" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktorVersion" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktorVersion" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktorVersion" }
+native-driver = { module = "com.squareup.sqldelight:native-driver", version.ref = "sqlDelightVersion" }
+rickclephas-kmm-viewmodel-core = { module = "com.rickclephas.kmm:kmm-viewmodel-core", version.ref = "kmmViewmodelCoreVersion" }
+runtime = { module = "com.squareup.sqldelight:runtime", version.ref = "sqlDelightVersion" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 01 20:54:39 CET 2024
+#Mon Mar 04 22:59:33 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/iosApp/iosApp/ExampleFeature/CounterView.swift
+++ b/iosApp/iosApp/ExampleFeature/CounterView.swift
@@ -1,0 +1,32 @@
+//
+//  CounterView.swift
+//  iosApp
+//
+//  Created by Radosław Czubak on 04/03/2024.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import SwiftUI
+import KMMViewModelSwiftUI
+import shared
+
+struct CounterView: View {
+    @StateViewModel var viewModel = shared.CounterViewModel()
+    var body: some View {
+        VStack(alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/){
+            Text("Counter: \(viewModel.state.counter)")
+            HStack{
+                Button(action: {viewModel.onEvent(counterEvent: CounterEventDecrement())}) {
+                    Text("Decrement")
+                }
+                Button(action: {viewModel.onEvent(counterEvent: CounterEventIncrement())}) {
+                    Text("Increment")
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    CounterView()
+}

--- a/iosApp/iosApp/KMMViewModel.swift
+++ b/iosApp/iosApp/KMMViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  CounterViewModel.swift
+//  iosApp
+//
+//  Created by Radosław Czubak on 05/03/2024.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import KMMViewModelCore
+import shared
+
+extension Kmm_viewmodel_coreKMMViewModel: KMMViewModel { }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct iOSApp: App {
 	var body: some Scene {
 		WindowGroup {
-			ContentView()
+			CounterView()
 		}
 	}
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,13 +1,15 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
+    id("com.google.devtools.ksp") version "1.9.22-1.0.17"
+    id("com.rickclephas.kmp.nativecoroutines") version "1.0.0-ALPHA-25"
 }
 
 kotlin {
     androidTarget {
         compilations.all {
             kotlinOptions {
-                jvmTarget = "1.8"
+                jvmTarget = "17"
             }
         }
     }
@@ -22,31 +24,31 @@ kotlin {
             isStatic = true
         }
     }
-    val coroutinesVersion = "1.7.3"
-    val ktorVersion = "2.3.7"
-    val sqlDelightVersion = "1.5.5"
-    val dateTimeVersion = "0.4.1"
     sourceSets {
-
+        all {
+            languageSettings.optIn("kotlinx.cinterop.ExperimentalForeignApi")
+            languageSettings.optIn("kotlin.experimental.ExperimentalObjCName")
+        }
         commonMain.dependencies {
-            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
-            implementation("io.ktor:ktor-client-core:$ktorVersion")
-            implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
-            implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
-            implementation("com.squareup.sqldelight:runtime:$sqlDelightVersion")
-            implementation("org.jetbrains.kotlinx:kotlinx-datetime:$dateTimeVersion")
+            implementation(libs.coroutines.core)
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.kotlinx.json)
+            implementation(libs.runtime)
+            implementation(libs.kotlinx.datetime)
+            api(libs.rickclephas.kmm.viewmodel.core)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }
         androidMain.dependencies {
-            implementation("io.ktor:ktor-client-android:$ktorVersion")
-            implementation("com.squareup.sqldelight:android-driver:$sqlDelightVersion")
+            implementation(libs.ktor.client.android)
+            implementation(libs.android.driver)
         }
 
         iosMain.dependencies {
-            implementation("io.ktor:ktor-client-darwin:$ktorVersion")
-            implementation("com.squareup.sqldelight:native-driver:$sqlDelightVersion")
+            implementation(libs.ktor.client.darwin)
+            implementation(libs.native.driver)
         }
     }
 }
@@ -56,5 +58,9 @@ android {
     compileSdk = 34
     defaultConfig {
         minSdk = 27
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }

--- a/shared/src/commonMain/kotlin/pl/radoslav/bikeer/examplefeature/presentation/CounterEvent.kt
+++ b/shared/src/commonMain/kotlin/pl/radoslav/bikeer/examplefeature/presentation/CounterEvent.kt
@@ -1,0 +1,6 @@
+package pl.radoslav.bikeer.examplefeature.presentation
+
+sealed interface CounterEvent {
+    data object Increment : CounterEvent
+    data object Decrement : CounterEvent
+}

--- a/shared/src/commonMain/kotlin/pl/radoslav/bikeer/examplefeature/presentation/CounterState.kt
+++ b/shared/src/commonMain/kotlin/pl/radoslav/bikeer/examplefeature/presentation/CounterState.kt
@@ -1,0 +1,5 @@
+package pl.radoslav.bikeer.examplefeature.presentation
+
+data class CounterState(
+    val counter: Int = 0
+)

--- a/shared/src/commonMain/kotlin/pl/radoslav/bikeer/examplefeature/presentation/CounterViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/radoslav/bikeer/examplefeature/presentation/CounterViewModel.kt
@@ -1,0 +1,25 @@
+package pl.radoslav.bikeer.examplefeature.presentation
+
+import com.rickclephas.kmm.viewmodel.KMMViewModel
+import com.rickclephas.kmm.viewmodel.MutableStateFlow
+import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesState
+import kotlinx.coroutines.flow.update
+
+open class CounterViewModel : KMMViewModel() {
+    private val _state = MutableStateFlow(viewModelScope, CounterState())
+
+    @NativeCoroutinesState
+    val state = _state
+
+    fun onEvent(counterEvent: CounterEvent) {
+        when (counterEvent) {
+            CounterEvent.Decrement -> _state.update { state ->
+                state.copy(counter = state.counter - 1)
+            }
+
+            CounterEvent.Increment -> _state.update { state ->
+                state.copy(counter = state.counter + 1)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Simple Counter feature to show ViewModel sharing between Android and iOS apps. 
Implemented simple UI with Jetpack Compose and SwiftUI.

Added: 
- Gradle Version Catalogs
- KMMViewModel library with KMPCoroutines
- Screen with working counter on Android and iOS 